### PR TITLE
dealing with shortnames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Use an official OpenJDK runtime as a parent image
 #FROM arm64v8/openjdk:17-ea-16-jdk
-FROM khipu/openjdk17-alpine:latest
+FROM docker.io/khipu/openjdk17-alpine:latest
+
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
Dockerfile updated, indicates:
-creation and use 'Upgrade_manifest_tekton' branch 
-complete base image name
-Arquitecture best practices
-dealing with shortnames